### PR TITLE
Class.inc revert. Bug fixes. AutoMedBreak behavior change. (#15)

### DIFF
--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1620,6 +1620,12 @@ SUB basics_MacroSettings
 /RETURN
 
 SUB basics_CharacterSettings
+/if (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]}) {
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+} else /if (${Me.Class.ShortName.NotEqual[BRD]}) {
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+}
+/if (${Me.Class.ShortName.NotEqual[BRD]}) /call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 
 Sub basics_Aliases

--- a/Macros/e3 Includes/e3_Classes_Beastlord.inc
+++ b/Macros/e3 Includes/e3_Classes_Beastlord.inc
@@ -40,8 +40,6 @@ Sub BST_Background_Events
 /return
 |----------------------------------------------------------------------------|
 SUB BST_CharacterSettings
-/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub BST_Aliases

--- a/Macros/e3 Includes/e3_Classes_Berserker.inc
+++ b/Macros/e3 Includes/e3_Classes_Berserker.inc
@@ -40,8 +40,6 @@ SUB BER_MacroSettings
 |----------------------------------------------------------------------------|
 SUB BER_CharacterSettings
 	/call WriteToIni "${Character_Ini},${Me.Class},Axe Ability" "Axe of the Destroyer/Reagent|Balanced Axe Components/CheckFor|20"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub BER_Aliases

--- a/Macros/e3 Includes/e3_Classes_Cleric.inc
+++ b/Macros/e3 Includes/e3_Classes_Cleric.inc
@@ -378,8 +378,6 @@ SUB CLR_CharacterSettings
   /call WriteToIni "${Character_Ini},Cleric,Yaulp Spell"
   /call WriteToIni "${Character_Ini},Cleric,Auto-Pet Weapons (On/Off)"
   /call WriteToIni "${Character_Ini},Cleric,Summoned Pet Hammer"
-  /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
-  /call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== CLR_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Druid.inc
+++ b/Macros/e3 Includes/e3_Classes_Druid.inc
@@ -20,8 +20,6 @@ SUB DRU_MacroSettings
 |----------------------------------------------------------------------------|
 SUB DRU_CharacterSettings
 	/call WriteToIni "${Character_Ini},Druid,Evac Spell"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub DRU_Aliases

--- a/Macros/e3 Includes/e3_Classes_Enchanter.inc
+++ b/Macros/e3 Includes/e3_Classes_Enchanter.inc
@@ -307,8 +307,6 @@ SUB ENC_CharacterSettings
   /call WriteToIni "${Character_Ini},Enchanter,Mez"
 	/call WriteToIni "${Character_Ini},Enchanter,Charm"
   /call WriteToIni "${Character_Ini},Enchanter,GatherMana Pct" 10
-  /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
-  /call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub ENC_Aliases

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -305,8 +305,6 @@ SUB MAG_CharacterSettings
 	/call WriteToIni "${Character_Ini},Magician,Auto-Pet Weapons (On/Off)"
   /call WriteToIni "${Character_Ini},Magician,Auto-Summon Orb of Mastery (On/Off)"
 	/call WriteToIni "${Character_Ini},Magician,Summoned Pet Item"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== MAG_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Monk.inc
+++ b/Macros/e3 Includes/e3_Classes_Monk.inc
@@ -27,8 +27,6 @@ SUB MNK_MacroSettings
 /RETURN
 |----------------------------------------------------------------------------|
 SUB MNK_CharacterSettings
-/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub MNK_Aliases

--- a/Macros/e3 Includes/e3_Classes_Necromancer.inc
+++ b/Macros/e3 Includes/e3_Classes_Necromancer.inc
@@ -117,8 +117,6 @@ SUB NEC_CharacterSettings
   |/call WriteToIni "${Character_Ini},${Me.Class},Mana Dump Engage Pct" 70
 	/call WriteToIni "${Character_Ini},${Me.Class},Who to Mana Dump"
 	/call WriteToIni "${Character_Ini},${Me.Class},Mana Dump"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== NEC_CharacterSettings -|
 /return
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Paladin.inc
+++ b/Macros/e3 Includes/e3_Classes_Paladin.inc
@@ -25,8 +25,6 @@ SUB PAL_CharacterSettings
 /if (${Debug}) /echo |- PAL_CharacterSettings ==>
 	/call WriteToIni "${Character_Ini},Paladin,Auto-Yaulp (On/Off)" Off
 	/call WriteToIni "${Character_Ini},Paladin,Yaulp Spell"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== PAL_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Ranger.inc
+++ b/Macros/e3 Includes/e3_Classes_Ranger.inc
@@ -23,8 +23,6 @@ SUB RNG_MacroSettings
 |----------------------------------------------------------------------------|
 SUB RNG_CharacterSettings
   /call WriteToIni "${Character_Ini},${Me.Class},TargetAE Ranged (On/Off)" Off
-  /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-  /call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /return
 |----------------------------------------------------------------------------|
 Sub RNG_Aliases

--- a/Macros/e3 Includes/e3_Classes_Rogue.inc
+++ b/Macros/e3 Includes/e3_Classes_Rogue.inc
@@ -86,8 +86,6 @@ SUB ROG_CharacterSettings
 	/call WriteToIni "${Character_Ini},${Me.Class},PoisonPR" "Bite of the Shissar XII"
 	/call WriteToIni "${Character_Ini},${Me.Class},PoisonFR" "Solusek's Burn XII"
 	/call WriteToIni "${Character_Ini},${Me.Class},PoisonCR" "E`ci's Lament XII"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 	/if (${Debug}) /echo <== ROG_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_ShadowKnight.inc
+++ b/Macros/e3 Includes/e3_Classes_ShadowKnight.inc
@@ -22,8 +22,6 @@ SUB SHD_MacroSettings
 SUB SHD_CharacterSettings
 /if (${Debug}) /echo |- SHD_CharacterSettings ==>
 	/call WriteToIni "${Character_Ini},${Me.Class},LifeTap"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== SHD_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Shaman.inc
+++ b/Macros/e3 Includes/e3_Classes_Shaman.inc
@@ -53,8 +53,6 @@ SUB SHM_CharacterSettings
 /if (${Debug}) /echo |- SHM_CharacterSettings ==>
 	/call WriteToIni "${Character_Ini},Shaman,Auto-Canni (On/Off)"
 	/call WriteToIni "${Character_Ini},Shaman,Canni"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== SHM_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Warrior.inc
+++ b/Macros/e3 Includes/e3_Classes_Warrior.inc
@@ -14,8 +14,6 @@ SUB WAR_MacroSettings
 /RETURN
 |----------------------------------------------------------------------------|
 SUB WAR_CharacterSettings
-/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub WAR_Aliases

--- a/Macros/e3 Includes/e3_Classes_Wizard.inc
+++ b/Macros/e3 Includes/e3_Classes_Wizard.inc
@@ -43,8 +43,6 @@ SUB WIZ_CharacterSettings
 	/call WriteToIni "${Character_Ini},Wizard,Evac Spell"
 	/call WriteToIni "${Character_Ini},Wizard,Auto-Harvest (On/Off)" Off
 	/call WriteToIni "${Character_Ini},Wizard,Harvest"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== WIZ_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -47,9 +47,13 @@ SUB Main(modeSelect)
       /if (${Me.CombatState.NotEqual[COMBAT]}) {
         /if ((!${Me.Casting.ID} || ${Me.Class.ShortName.Equal[BRD]}) && !${use_TargetAE}) /call completePendingExchange
         /if (!${Me.Moving} && !${Following} && !${Me.Casting.ID}) {
-          /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1 && ${autoMedChar}) || (${Me.PctEndurance} < ${autoMedPctMana})) {
+          /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1 && ${autoMedChar}) || (${Me.PctEndurance} < ${autoMedPctMana} && ${autoMedChar})) {
             /varset medBreak TRUE
-			/if (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]}) /varset AssistType Off
+			/if ((${Defined[AssistType]}) && (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]})) {
+			  /varset AssistType Off 
+			} else {
+			  /declare AssistType string Off
+			}
           }
         }
       }


### PR DESCRIPTION
* Auto Med Settings Per Char

Added auto med settings and end med in combat settings per character. Also now stops casters from trying to /stick while medding in combat. None of this applies to bards because the macro set excludes bards from medbreak.

Requires the addition of two lines under [Misc] for existing characters:

End MedBreak in Combat(On/Off)=On
AutoMedBreak (On/Off)=Off

End MedBreak in Combat honors the same setting in General Settings.ini like Auto Loot. If one is off, it's off entirely.

AutoMedBreak honors your AutoMedBreak ManaPct setting in General Settings.ini. If it's 0, it's off.

Added logical default settings to be applied for all (non-bard) classes for new characters.

* Update e3.mac

* Revert "Update e3.mac"

This reverts commit 9baf6168d234168fd4a34aa76edf5c0331ded9a0.

* Quick AutoMed Update

Just making the behavior uniform for mana and end. Melee classes should really keep automed off, though.

* Class Inc Cleanup/Varset Bug Fix

Removed the WriteToIni entries from the class.incs and have the entries made from basics.inc instead.

Fixed e3.mac to declare AssistType if it isn't already declared to avoid a new character bug.

* Syntax Fix

Someone may or may not have forgotton a &&. I'm not saying it was me. But it was me.

* One more bug fix.

Had to change the autoMedChar checks and add them to both the end and mana sides. It wasn't parsing for some reason otherwise. I haven't no idea. It works as intended now.

* e3_Basics and e3.mac readability

Requested changes.

* Further Readability Changes